### PR TITLE
added new matches to `have_a_field`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Where a valid type for the expectation is either:
    - A String representation of a type: `"String!"`, `"Int!"`, `"[String]!"`
    (note the exclamation mark at the end, as required by the [GraphQL specs](http://graphql.org/).
 
+Testing `:property`, `:hash_key` and *metadata* is also possible by chaining `.with_property`, `.with_hash_key` and `.with_metadata`. For example:
+
+  - `expect(a_graphql_object).to have_a_field(field_name).with_property(property_name).with_metadata(metadata_hash)`
+  - `expect(a_graphql_object).to have_a_field(field_name).with_hash_key(hash_key)`
+
 ## Examples
 
 Given a `GraphQL::ObjectType` defined as
@@ -36,9 +41,15 @@ PostType = GraphQL::ObjectType.define do
 
   interfaces [GraphQL::Relay::Node.interface]
 
-  field :id, !types.ID
+  field :id, !types.ID,
+             property: :post_id
 
-  field :comments, !types[types.String]
+  field :comments,
+        !types[types.String],
+        hash_key: :post_comments
+
+  field :isPublished,
+        admin_only: true
 
   field :subposts, PostType do
     type !PostType
@@ -109,7 +120,17 @@ describe PostType do
 end
 ```
 
-### 3) Test the arguments accepted by a field with `accept_arguments` matcher:
+### 3) Test a specific field with `with_property`, `with_hash_key` and `with_metadata`
+
+```ruby
+describe PostType do
+  it { is_expected.to have_a_field(:id).with_property(:post_id) }
+  it { is_expected.to have_a_field(:comments).with_hash_key(:post_comments) }
+  it { is_expected.to have_a_field(:isPublished).with_metadata(admin_only: true) }
+end
+```
+
+### 4) Test the arguments accepted by a field with `accept_arguments` matcher:
 
 ```ruby
 describe PostType do
@@ -136,7 +157,7 @@ defined on the field.
 For better fluency, `accept_arguments` is also available in singular form, as
 `accept_argument`.
 
-### 4) Test an object's interface implementations:
+### 5) Test an object's interface implementations:
 
 ```ruby
 describe PostType do

--- a/lib/rspec/graphql_matchers/have_a_field.rb
+++ b/lib/rspec/graphql_matchers/have_a_field.rb
@@ -67,7 +67,7 @@ module RSpec
       def descriptions
         @expectations.map do |expectation|
           name, expected_value = expectation
-          DESCRIPTIONS[name] % [expected_value]
+          format(DESCRIPTIONS[name], expected_value)
         end
       end
 
@@ -76,7 +76,7 @@ module RSpec
         @results.each do |result|
           name, match = result
           next if match
-          return "but the %s was `%s`" % [name, @actual_field.send(name)]
+          return format('but the %s was `%s`', name, @actual_field.send(name))
         end
       end
 

--- a/lib/rspec/graphql_matchers/have_a_field.rb
+++ b/lib/rspec/graphql_matchers/have_a_field.rb
@@ -3,6 +3,13 @@ require_relative 'base_matcher'
 module RSpec
   module GraphqlMatchers
     class HaveAField < BaseMatcher
+      DESCRIPTIONS = {
+        type: 'of type `%s`',
+        property: 'reading from the `%s` property',
+        hash_key: 'reading from the `%s` hash_key',
+        metadata: 'with metadata `%s`'
+      }.freeze
+
       def initialize(expected_field_name, fields = :fields)
         @expected_field_name = expected_field_name.to_s
         @fields = fields.to_sym
@@ -18,38 +25,30 @@ module RSpec
 
         @results = @expectations.map do |expectaiton|
           name, expected_value = expectaiton
-          [name, send("#{name}_matches?", expected_value)]
+          [name, expectation_matches?(name, expected_value)]
         end.to_h
         @results.values.all?
       end
 
       def that_returns(expected_field_type)
         @expectations << [:type, expected_field_type]
-        @descriptions << "of type `#{expected_field_type}`"
-
         self
       end
       alias returning that_returns
       alias of_type that_returns
 
       def with_property(expected_property_name)
-        @expectations << [:property, expected_property_name.to_s]
-        @descriptions << "reading from the `#{expected_property_name}` property"
-
+        @expectations << [:property, expected_property_name]
         self
       end
 
       def with_hash_key(expected_hash_key)
-        @expectations << [:hash_key, expected_hash_key.to_s]
-        @descriptions << "reading from the `#{expected_hash_key}` hash_key"
-
+        @expectations << [:hash_key, expected_hash_key]
         self
       end
 
       def with_metadata(expected_metadata)
         @expectations << [:metadata, expected_metadata]
-        @descriptions << "with metadata `#{expected_metadata.inspect}`"
-
         self
       end
 
@@ -59,58 +58,44 @@ module RSpec
       end
 
       def description
-        ["define field `#{@expected_field_name}`"].concat(@descriptions).join(', ')
+        ["define field `#{@expected_field_name}`"]
+          .concat(descriptions).join(', ')
       end
 
       private
+
+      def descriptions
+        @expectations.map do |expectation|
+          name, expected_value = expectation
+          DESCRIPTIONS[name] % [expected_value]
+        end
+      end
 
       def explanation
         return 'but no field was found with that name' unless @actual_field
         @results.each do |result|
           name, match = result
-          return send("#{name}_explanation") unless match
+          next if match
+          return "but the %s was `%s`" % [name, @actual_field.send(name)]
         end
       end
 
-      def type_matches?(expected_field_type)
-        raise method_missing_error(:type) unless @actual_field.respond_to?(:type)
-        types_match?(@actual_field.type, expected_field_type)
+      def expectation_matches?(name, expected_value)
+        ensure_method_exists!(name)
+        if expected_value.is_a?(Hash)
+          @actual_field.send(name) == expected_value
+        else
+          @actual_field.send(name).to_s == expected_value.to_s
+        end
       end
 
-      def property_matches?(expected_property_name)
-        raise method_missing_error(:property) unless @actual_field.respond_to?(:property)
-        @actual_field.property.to_s == expected_property_name
-      end
-
-      def hash_key_matches?(expected_hash_key)
-        raise method_missing_error(:hash_key) unless @actual_field.respond_to?(:hash_key)
-        @actual_field.hash_key.to_s == expected_hash_key
-      end
-
-      def metadata_matches?(expected_metadata)
-        @actual_field.metadata == expected_metadata
-      end
-
-      def type_explanation
-        "but the field type was `#{@actual_field.type}`"
-      end
-
-      def property_explanation
-        "but the property was `#{@actual_field.property}`"
-      end
-
-      def hash_key_explanation
-        "but the hash_key was `#{@actual_field.hash_key}`"
-      end
-
-      def metadata_explanation
-        "but the metadata was `#{@actual_field.metadata.inspect}`"
-      end
-
-      def method_missing_error(method_name)
-        "The `#{@expected_field_name}` field defined by the GraphQL " \
-          "object does\'t seem valid as it does not respond to ##{method_name}. " \
+      def ensure_method_exists!(method_name)
+        return if @actual_field.respond_to?(method_name)
+        raise(
+          "The `#{@expected_field_name}` field defined by the GraphQL object " \
+          "does\'t seem valid as it does not respond to ##{method_name}. " \
           "\n\n\tThe field found was #{@actual_field.inspect}. "
+        )
       end
 
       def describe_obj(field)

--- a/lib/rspec/graphql_matchers/have_a_field.rb
+++ b/lib/rspec/graphql_matchers/have_a_field.rb
@@ -5,24 +5,53 @@ module RSpec
     class HaveAField < BaseMatcher
       def initialize(expected_field_name, fields = :fields)
         @expected_field_name = expected_field_name.to_s
-        @expected_field_type = @graph_object = nil
         @fields = fields.to_sym
+        @expectations = []
+        @descriptions = []
       end
 
       def matches?(graph_object)
         @graph_object = graph_object
 
         @actual_field = field_collection[@expected_field_name]
-        valid_field? && types_match?(@actual_field.type, @expected_field_type)
+        return false if @actual_field.nil?
+
+        @results = @expectations.map do |expectaiton|
+          name, expected_value = expectaiton
+          [name, send("#{name}_matches?", expected_value)]
+        end.to_h
+        @results.values.all?
       end
 
       def that_returns(expected_field_type)
-        @expected_field_type = expected_field_type
+        @expectations << [:type, expected_field_type]
+        @descriptions << "of type `#{expected_field_type}`"
 
         self
       end
       alias returning that_returns
       alias of_type that_returns
+
+      def with_property(expected_property_name)
+        @expectations << [:property, expected_property_name.to_s]
+        @descriptions << "reading from the `#{expected_property_name}` property"
+
+        self
+      end
+
+      def with_hash_key(expected_hash_key)
+        @expectations << [:hash_key, expected_hash_key.to_s]
+        @descriptions << "reading from the `#{expected_hash_key}` hash_key"
+
+        self
+      end
+
+      def with_metadata(expected_metadata)
+        @expectations << [:metadata, expected_metadata]
+        @descriptions << "with metadata `#{expected_metadata.inspect}`"
+
+        self
+      end
 
       def failure_message
         "expected #{describe_obj(@graph_object)} to " \
@@ -30,33 +59,58 @@ module RSpec
       end
 
       def description
-        "define field `#{@expected_field_name}`" + of_type_description
+        ["define field `#{@expected_field_name}`"].concat(@descriptions).join(', ')
       end
 
       private
 
       def explanation
         return 'but no field was found with that name' unless @actual_field
+        @results.each do |result|
+          name, match = result
+          return send("#{name}_explanation") unless match
+        end
+      end
 
+      def type_matches?(expected_field_type)
+        raise method_missing_error(:type) unless @actual_field.respond_to?(:type)
+        types_match?(@actual_field.type, expected_field_type)
+      end
+
+      def property_matches?(expected_property_name)
+        raise method_missing_error(:property) unless @actual_field.respond_to?(:property)
+        @actual_field.property.to_s == expected_property_name
+      end
+
+      def hash_key_matches?(expected_hash_key)
+        raise method_missing_error(:hash_key) unless @actual_field.respond_to?(:hash_key)
+        @actual_field.hash_key.to_s == expected_hash_key
+      end
+
+      def metadata_matches?(expected_metadata)
+        @actual_field.metadata == expected_metadata
+      end
+
+      def type_explanation
         "but the field type was `#{@actual_field.type}`"
       end
 
-      def valid_field?
-        unless @expected_field_type.nil? || @actual_field.respond_to?(:type)
-          error_msg = "The `#{@expected_field_name}` field defined by the GraphQL " \
-          'object does\'t seem valid as it does not respond to #type. ' \
-          "\n\n\tThe field found was #{@actual_field.inspect}. "
-          puts error_msg
-          raise error_msg
-        end
-
-        @actual_field
+      def property_explanation
+        "but the property was `#{@actual_field.property}`"
       end
 
-      def of_type_description
-        return '' unless @expected_field_type
+      def hash_key_explanation
+        "but the hash_key was `#{@actual_field.hash_key}`"
+      end
 
-        " of type `#{@expected_field_type}`"
+      def metadata_explanation
+        "but the metadata was `#{@actual_field.metadata.inspect}`"
+      end
+
+      def method_missing_error(method_name)
+        "The `#{@expected_field_name}` field defined by the GraphQL " \
+          "object does\'t seem valid as it does not respond to ##{method_name}. " \
+          "\n\n\tThe field found was #{@actual_field.inspect}. "
       end
 
       def describe_obj(field)

--- a/spec/rspec/have_a_field_matcher_spec.rb
+++ b/spec/rspec/have_a_field_matcher_spec.rb
@@ -62,13 +62,13 @@ module RSpec::GraphqlMatchers
         expect { expect(a_type).to have_a_field(:id).returning('String!') }
           .to fail_with(
             "expected #{a_type.inspect} to define field `id`, of type `String!`," \
-            ' but the field type was `String`.'
+            ' but the type was `String`.'
           )
 
         expect { expect(a_type).to have_a_field('other').returning(!types.Int) }
           .to fail_with(
             "expected #{a_type.inspect} to define field `other`, of type `Int!`," \
-            ' but the field type was `ID!`.'
+            ' but the type was `ID!`.'
           )
       end
 

--- a/spec/rspec/have_a_return_field_spec.rb
+++ b/spec/rspec/have_a_return_field_spec.rb
@@ -50,13 +50,13 @@ module RSpec::GraphqlMatchers
       expect { expect(a_type).to have_a_return_field(:id).returning('String!') }
         .to fail_with(
           "expected #{a_type.name} to define field `id`, of type `String!`," \
-          ' but the field type was `String`.'
+          ' but the type was `String`.'
         )
 
       expect { expect(a_type).to have_a_return_field('other').returning(!types.Int) }
         .to fail_with(
           "expected #{a_type.name} to define field `other`, of type `Int!`," \
-          ' but the field type was `ID!`.'
+          ' but the type was `ID!`.'
         )
     end
 

--- a/spec/rspec/have_a_return_field_spec.rb
+++ b/spec/rspec/have_a_return_field_spec.rb
@@ -49,13 +49,13 @@ module RSpec::GraphqlMatchers
     it 'fails when the type defines a field of the wrong type' do
       expect { expect(a_type).to have_a_return_field(:id).returning('String!') }
         .to fail_with(
-          "expected #{a_type.name} to define field `id` of type `String!`," \
+          "expected #{a_type.name} to define field `id`, of type `String!`," \
           ' but the field type was `String`.'
         )
 
       expect { expect(a_type).to have_a_return_field('other').returning(!types.Int) }
         .to fail_with(
-          "expected #{a_type.name} to define field `other` of type `Int!`," \
+          "expected #{a_type.name} to define field `other`, of type `Int!`," \
           ' but the field type was `ID!`.'
         )
     end

--- a/spec/rspec/have_an_input_field_matcher_spec.rb
+++ b/spec/rspec/have_an_input_field_matcher_spec.rb
@@ -50,13 +50,13 @@ module RSpec::GraphqlMatchers
       expect { expect(a_type).to have_an_input_field(:id).returning('String!') }
         .to fail_with(
           "expected #{a_type.name} to define field `id`, of type `String!`," \
-          ' but the field type was `String`.'
+          ' but the type was `String`.'
         )
 
       expect { expect(a_type).to have_an_input_field('other').returning(!types.Int) }
         .to fail_with(
           "expected #{a_type.name} to define field `other`, of type `Int!`," \
-          ' but the field type was `ID!`.'
+          ' but the type was `ID!`.'
         )
     end
 

--- a/spec/rspec/have_an_input_field_matcher_spec.rb
+++ b/spec/rspec/have_an_input_field_matcher_spec.rb
@@ -49,13 +49,13 @@ module RSpec::GraphqlMatchers
     it 'fails when the type defines a field of the wrong type' do
       expect { expect(a_type).to have_an_input_field(:id).returning('String!') }
         .to fail_with(
-          "expected #{a_type.name} to define field `id` of type `String!`," \
+          "expected #{a_type.name} to define field `id`, of type `String!`," \
           ' but the field type was `String`.'
         )
 
       expect { expect(a_type).to have_an_input_field('other').returning(!types.Int) }
         .to fail_with(
-          "expected #{a_type.name} to define field `other` of type `Int!`," \
+          "expected #{a_type.name} to define field `other`, of type `Int!`," \
           ' but the field type was `ID!`.'
         )
     end

--- a/spec/rspec/readme_spec.rb
+++ b/spec/rspec/readme_spec.rb
@@ -10,6 +10,12 @@ describe 'The readme Examples' do
     )
   )
 
+  before do
+    GraphQL::Field.accepts_definitions(
+      admin_only: GraphQL::Define.assign_metadata_key(:admin_only)
+    )
+  end
+
   readme_content.scan(ruby_code_regex) do |ruby_code|
     eval(ruby_code[0])
   end


### PR DESCRIPTION
This addresses #3 by adding a `with_property` matcher to `have_a_field`

Additionally I have added `with_hash_key` and `with_metadata`.

A matcher could be added to the `:as` property on [Argument](http://www.rubydoc.info/gems/graphql/1.6.6/GraphQL/Argument#as-instance_method) too but I've left it out of this PR for now to keep it as small as possible.

I have a few other ideas for additional matchers on `have_a_field`.

It would be nice to have a `with_description`. The argument could be optional to test *if* a field has a description, or with an argument *that* the description matches.

Possibilities are endless, I'll add my ideas to the issues.