### PR TITLE
Add support for deprecation reason

### DIFF
--- a/lib/rspec/graphql_matchers/have_a_field.rb
+++ b/lib/rspec/graphql_matchers/have_a_field.rb
@@ -7,7 +7,8 @@ module RSpec
         type: 'of type `%s`',
         property: 'reading from the `%s` property',
         hash_key: 'reading from the `%s` hash_key',
-        metadata: 'with metadata `%s`'
+        metadata: 'with metadata `%s`',
+        deprecation_reason: 'with deprecation reason `%s`'
       }.freeze
 
       def initialize(expected_field_name, fields = :fields)
@@ -49,6 +50,11 @@ module RSpec
 
       def with_metadata(expected_metadata)
         @expectations << [:metadata, expected_metadata]
+        self
+      end
+
+      def with_deprecation_reason(expected_deprecation_reason)
+        @expectations << [:deprecation_reason, expected_deprecation_reason]
         self
       end
 

--- a/spec/rspec/have_a_field_matcher_spec.rb
+++ b/spec/rspec/have_a_field_matcher_spec.rb
@@ -9,6 +9,7 @@ module RSpec::GraphqlMatchers
         field :id,
           types.String,
           property: :id_on_model,
+          deprecation_reason: 'Deprecated',
           foo: true,
           bar: { nested: { objects: true, arrays: [1, 2, 3] } }
 
@@ -100,6 +101,49 @@ module RSpec::GraphqlMatchers
         it 'fails with a Runtime error' do
           expect { expect(a_type).to have_a_field(:id).of_type(!types.Int) }
             .to raise_error(RuntimeError)
+        end
+      end
+    end
+
+    describe '.with_deprecation_reason(deprecation_reason)' do
+      context 'when a deprecation reason is present' do
+        it 'passes when the deprecation reason is correct' do
+          expect(a_type).to have_a_field(:id)
+            .with_deprecation_reason('Deprecated')
+        end
+
+        it 'fails when the deprecation reason is incorrect' do
+          expect do
+            expect(a_type).to have_a_field(:id)
+              .with_deprecation_reason('whatever')
+          end.to fail_with(
+            "expected #{a_type.inspect} to define field `id`," \
+            ' with deprecation reason `whatever`,' \
+            ' but the deprecation_reason was `Deprecated`.'
+          )
+        end
+      end
+
+      context 'when there is no deprecation reason present' do
+        subject(:a_type) do
+          GraphQL::ObjectType.define do
+            name 'TestObject'
+
+            field :id,
+              types.String,
+              property: :id_on_model
+          end
+        end
+
+        it 'fails when the reasons do not match' do
+          expect do
+            expect(a_type).to have_a_field(:id)
+              .with_deprecation_reason('whatever')
+          end.to fail_with(
+            "expected #{a_type.inspect} to define field `id`," \
+            ' with deprecation reason `whatever`,' \
+            ' but the deprecation_reason was ``.'
+          )
         end
       end
     end


### PR DESCRIPTION
# Background
Sometimes fields on a type are deprecated.
To show users of the API why a field was deprecated
a deprecation reason is attached to the field.
This PR introduces the ability to test for these cases.

# Implementation
Adds a method `with_deprecation_reason(deprecation_reason)`
that can be used when testing a field on a type.

# Changes
- Add `with_deprecation_reason` to the field matcher
- Add tests for `with_deprecation_reason`

Closes #13 