### PR TITLE
Fix field collection for GraphQL 1.8

### DIFF
--- a/lib/rspec/graphql_matchers/have_a_field.rb
+++ b/lib/rspec/graphql_matchers/have_a_field.rb
@@ -105,6 +105,8 @@ module RSpec
       def field_collection
         if @graph_object.respond_to?(@fields)
           @graph_object.public_send(@fields)
+        elsif @graph_object.class.respond_to?(@fields)
+          @graph_object.class.public_send(@fields)
         else
           raise "Invalid object #{@graph_object} provided to #{matcher_name} " \
             'matcher. It does not seem to be a valid GraphQL object type.'


### PR DESCRIPTION
In Ruby GraphQL 1.8, the `fields` method is on the class rather than instance of defined types.

EDIT: Looks like this is going to be quite a bit more work to support 1.8. More stuff is broken further along the validation process here.