### PR TITLE
Add subject to type spec example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ end
 
 ```ruby
 describe PostType do
+  subject { described_class }
+
   it 'defines a field id of type ID!' do
     expect(subject).to have_field(:id).that_returns(!types.ID)
   end


### PR DESCRIPTION
Similarly to the [next item](https://github.com/khamusa/rspec-graphql_matchers/blame/45a998baed008eb790d5ad3aab7101a041fd84e3/README.md#L83), we should define a subject before the class-based test will pass 