### PR TITLE
Remove pry requirement from be_of_type matcher

### DIFF
--- a/lib/rspec/graphql_matchers/be_of_type.rb
+++ b/lib/rspec/graphql_matchers/be_of_type.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative 'base_matcher'
-require 'pry'
 
 module RSpec
   module GraphqlMatchers


### PR DESCRIPTION
It looks like commit baf670a5ef99a8c07612364fc5ae9c13e85fabc3 accidentally re-added a `require 'pry'`

First time contributing to another repo :)