### PR TITLE
Compatibility with version 1.9 of the graphql gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,9 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in rspec-graphql_matchers.gemspec
 gemspec
+
+if ENV['GRAPHQL_GEM_VERSION'] == '1.8'
+  gem 'graphql', '~> 1.8.0'
+elsif ENV['GRAPHQL_GEM_VERSION'] == '1.9'
+  gem 'graphql', '~> 1.9.0'
+end

--- a/lib/rspec/graphql_matchers/have_a_field.rb
+++ b/lib/rspec/graphql_matchers/have_a_field.rb
@@ -19,6 +19,7 @@ module RSpec
         @graph_object = graph_object
 
         @actual_field = field_collection[@expected_field_name]
+        @actual_field = @actual_field.to_graphql if @actual_field.respond_to?(:to_graphql)
         return false if @actual_field.nil?
 
         @results = @expectations.reject do |matcher|

--- a/lib/rspec/graphql_matchers/have_a_field_matchers/with_hash_key.rb
+++ b/lib/rspec/graphql_matchers/have_a_field_matchers/with_hash_key.rb
@@ -23,11 +23,10 @@ module RSpec
 
         def get_hash_key(actual_field)
           if actual_field.respond_to?(:hash_key)
-            return actual_field.hash_key.to_sym
+            return actual_field.hash_key.to_sym if actual_field.hash_key
           end
 
-          # Class-based api
-          actual_field.method_sym
+          actual_field.metadata[:type_class].method_sym
         end
       end
     end

--- a/lib/rspec/graphql_matchers/have_a_field_matchers/with_property.rb
+++ b/lib/rspec/graphql_matchers/have_a_field_matchers/with_property.rb
@@ -11,12 +11,20 @@ module RSpec
         end
 
         def matches?(actual_field)
-          @actual_property = actual_field.property.to_sym
+          @actual_property = property(actual_field).to_sym
           @actual_property == @expected_property_name.to_sym
         end
 
         def failure_message
           "#{description}, but it was `#{@actual_property}`"
+        end
+
+        private
+
+        def property(field)
+          property = field.property
+          property = field.metadata[:type_class].method_sym if property.nil?
+          property
         end
       end
     end

--- a/rspec-graphql_matchers.gemspec
+++ b/rspec-graphql_matchers.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'graphql', '>= 1.8', '< 1.9'
+  spec.add_runtime_dependency 'graphql', '>= 1.8', '< 2.0'
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rubocop', '0.71'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
This PR contains some fixes to make it work with versions 1.9.X of the graphql gem.