### PR TITLE
Added support of underscored arguments in have_field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ sudo: false
 language: ruby
 rvm:
   - 2.3.1
-before_install:
-  - gem install bundler -v 1.12.3
-  - bundle _1.12.3_ install
+before_install: gem install bundler -v 1.12.3
 script: bundle exec rspec
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ sudo: false
 language: ruby
 rvm:
   - 2.3.1
-before_install:
-  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
-  - gem install bundler -v '< 2'
+before_install: gem install bundler -v 1.12.3
 script: bundle exec rspec
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ sudo: false
 language: ruby
 rvm:
   - 2.3.1
-before_install: gem install bundler -v 1.12.3
+before_install:
+  - gem install bundler -v 1.12.3
+  - bundle _1.12.3_ install
 script: bundle exec rspec
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ sudo: false
 language: ruby
 rvm:
   - 2.3.1
-before_install: gem install bundler -v 1.12.3
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 script: bundle exec rspec
 matrix:
   include:

--- a/lib/rspec/graphql_matchers/have_a_field.rb
+++ b/lib/rspec/graphql_matchers/have_a_field.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'graphql/schema/member/build_type'
 require_relative 'base_matcher'
 require_relative './have_a_field_matchers/of_type'
 require_relative './have_a_field_matchers/with_property'
@@ -10,7 +11,7 @@ module RSpec
   module GraphqlMatchers
     class HaveAField < BaseMatcher
       def initialize(expected_field_name, fields = :fields)
-        @expected_field_name = expected_field_name.to_s
+        @expected_field_name = GraphQL::Schema::Member::BuildType.camelize(expected_field_name.to_s)
         @fields = fields.to_sym
         @expectations = []
       end

--- a/lib/rspec/graphql_matchers/have_a_field.rb
+++ b/lib/rspec/graphql_matchers/have_a_field.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'graphql/schema/member/build_type'
 require_relative 'base_matcher'
 require_relative './have_a_field_matchers/of_type'
 require_relative './have_a_field_matchers/with_property'

--- a/rspec-graphql_matchers.gemspec
+++ b/rspec-graphql_matchers.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'graphql', '>= 1.8', '< 2.0'
-  spec.add_development_dependency 'bundler', '~> 1.12'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rubocop', '0.71'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'pry', '~> 0'

--- a/spec/rspec/have_a_field_matcher_spec.rb
+++ b/spec/rspec/have_a_field_matcher_spec.rb
@@ -11,6 +11,14 @@ module RSpec::GraphqlMatchers
         expect(a_type).to have_a_field(:id)
       end
 
+      it 'passes with the underscored field name' do
+        expect(a_type).to have_a_field(:is_test)
+      end
+
+      it 'passes with the camel cased field name' do
+        expect(a_type).to have_a_field(:isTest)
+      end
+
       it 'fails when the type does not define the expected field' do
         expect { expect(a_type).to have_a_field(:ids) }
           .to fail_with(
@@ -39,12 +47,16 @@ module RSpec::GraphqlMatchers
           'strings' do
           expect(a_type).to have_a_field(:id).that_returns('ID!')
           expect(a_type).to have_a_field('other').that_returns('String')
+          expect(a_type).to have_a_field(:is_test).of_type('Boolean')
+          expect(a_type).to have_a_field(:isTest).of_type('Boolean')
         end
 
         it 'passes when the type defines the field with correct type as ' \
           'graphql objects' do
           expect(a_type).to have_a_field(:id).that_returns('ID!')
           expect(a_type).to have_a_field('other').of_type(types.String)
+          expect(a_type).to have_a_field(:is_test).of_type(types.Boolean)
+          expect(a_type).to have_a_field(:isTest).of_type(types.Boolean)
         end
 
         it 'fails when the type defines a field of the wrong type' do
@@ -97,6 +109,7 @@ module RSpec::GraphqlMatchers
 
           field :id, types.ID, null: false
           field :other, types.String, hash_key: :other_on_hash, null: true
+          field :is_test, types.Boolean, null: true
         end
       end
 
@@ -109,6 +122,7 @@ module RSpec::GraphqlMatchers
             graphql_name 'ActualInterface'
 
             field :other, types.String, hash_key: :other_on_hash, null: true
+            field :is_test, types.Boolean, null: true
           end
 
           Class.new(GraphQL::Schema::Object) do
@@ -137,6 +151,8 @@ module RSpec::GraphqlMatchers
           field :other,
                 types.String,
                 hash_key: :other_on_hash
+
+          field :isTest, types.Boolean
         end
       end
 


### PR DESCRIPTION
The simple solution for underscored arguments in the `have_field` matcher. Fixed #28 