### PR TITLE
Add support for underscored argument names in accept_argument(s)

### DIFF
--- a/lib/rspec/graphql_matchers/accept_argument.rb
+++ b/lib/rspec/graphql_matchers/accept_argument.rb
@@ -17,12 +17,16 @@ module RSpec
         end
 
         @expected_arg_name = expected_arg_name.to_s
+        @expected_camel_arg_name = GraphQL::Schema::Member::BuildType.camelize(
+          @expected_arg_name
+        )
       end
 
       def matches?(graph_object)
         @graph_object = graph_object
 
         @actual_argument = field_arguments[@expected_arg_name]
+        @actual_argument ||= field_arguments[@expected_camel_arg_name]
         return false if @actual_argument.nil?
 
         @results = @expectations.select do |matcher|

--- a/lib/rspec/graphql_matchers/accept_arguments.rb
+++ b/lib/rspec/graphql_matchers/accept_arguments.rb
@@ -29,7 +29,9 @@ module RSpec
       private
 
       def matches_argument?(arg_name, arg_type)
+        camel_arg_name = GraphQL::Schema::Member::BuildType.camelize(arg_name.to_s)
         actual_arg = actual_field.arguments[arg_name.to_s]
+        actual_arg ||= actual_field.arguments[camel_arg_name]
 
         actual_arg && types_match?(actual_arg.type, arg_type)
       end

--- a/spec/rspec/accept_argument_matcher_spec.rb
+++ b/spec/rspec/accept_argument_matcher_spec.rb
@@ -9,6 +9,18 @@ module RSpec::GraphqlMatchers
         expect(a_type).to accept_argument(:id)
       end
 
+      it 'passes with the underscored argument name' do
+        expect(a_type).to accept_argument(:is_test)
+      end
+
+      it 'passes with the camel cased argument name' do
+        expect(a_type).to accept_argument(:isTest)
+      end
+
+      it 'matches a non camelized argument with the underscored argument name' do
+        expect(a_type).to accept_argument(:not_camelized)
+      end
+
       it 'fails when the type does not define the expected field' do
         expect { expect(a_type).to accept_argument(:ids) }
           .to fail_with(
@@ -89,6 +101,8 @@ module RSpec::GraphqlMatchers
 
           argument :id, GraphQL::Types::String, required: false
           argument :other, GraphQL::Types::ID, required: true
+          argument :is_test, GraphQL::Types::Boolean, required: false
+          argument :not_camelized, GraphQL::Types::Boolean, required: false, camelize: false
         end
       end
 
@@ -102,6 +116,8 @@ module RSpec::GraphqlMatchers
 
           argument :id, types.String
           argument :other, !types.ID
+          argument :isTest, types.Boolean
+          argument :not_camelized, types.Boolean
         end
       end
 

--- a/spec/rspec/accept_arguments_matcher_spec.rb
+++ b/spec/rspec/accept_arguments_matcher_spec.rb
@@ -22,6 +22,24 @@ describe 'expect(a_field).to accept_arguments(arg_name: arg_type, ...)' do
 
           it { is_expected.not_to accept_arguments(expected_args) }
         end
+
+        context 'when the expected argument is camelcase' do
+          let(:expected_args) { { isTest: types.Boolean } }
+
+          it { is_expected.to accept_arguments(expected_args) }
+        end
+
+        context 'when the expected argument is underscored' do
+          let(:expected_args) { { is_test: types.Boolean } }
+
+          it { is_expected.to accept_arguments(expected_args) }
+
+          context 'when the actual argument is not camelized' do
+            let(:expected_args) { { not_camelized: types.Boolean } }
+
+            it { is_expected.to accept_arguments(expected_args) }
+          end
+        end
       end
 
       context 'when expecting multiple arguments with type' do
@@ -122,6 +140,8 @@ describe 'expect(a_field).to accept_arguments(arg_name: arg_type, ...)' do
         argument :id, !types.ID
         argument :name, !types.String
         argument :age, types.Int
+        argument :isTest, types.Boolean
+        argument :not_camelized, types.Boolean
       end
     end
 
@@ -136,6 +156,8 @@ describe 'expect(a_field).to accept_arguments(arg_name: arg_type, ...)' do
         argument :id, GraphQL::Types::ID, required: true
         argument :name, GraphQL::Types::String, required: true
         argument :age, GraphQL::Types::Int, required: false
+        argument :is_test, GraphQL::Types::Boolean, required: false
+        argument :not_camelized, GraphQL::Types::Boolean, required: false, camelize: false
       end
     end
 


### PR DESCRIPTION
Allows for underscored argument names in the `accept_argument` and `accept_arguments` matchers.