### PR TITLE
Add `with_deprecation_reason` matcher to `have_a_field`

### DIFF
--- a/lib/rspec/graphql_matchers/have_a_field.rb
+++ b/lib/rspec/graphql_matchers/have_a_field.rb
@@ -5,6 +5,7 @@ require_relative './have_a_field_matchers/of_type'
 require_relative './have_a_field_matchers/with_property'
 require_relative './have_a_field_matchers/with_metadata'
 require_relative './have_a_field_matchers/with_hash_key'
+require_relative './have_a_field_matchers/with_deprecation_reason'
 
 module RSpec
   module GraphqlMatchers
@@ -51,6 +52,11 @@ module RSpec
 
       def with_metadata(expected_metadata)
         @expectations << HaveAFieldMatchers::WithMetadata.new(expected_metadata)
+        self
+      end
+
+      def with_deprecation_reason(expected_reason = nil)
+        @expectations << HaveAFieldMatchers::WithDeprecationReason.new(expected_reason)
         self
       end
 

--- a/lib/rspec/graphql_matchers/have_a_field_matchers/with_deprecation_reason.rb
+++ b/lib/rspec/graphql_matchers/have_a_field_matchers/with_deprecation_reason.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module RSpec
+  module GraphqlMatchers
+    module HaveAFieldMatchers
+      class WithDeprecationReason
+        def initialize(expected_reason)
+          @expected_reason = expected_reason
+        end
+
+        def matches?(actual_field)
+          @actual_reason = actual_field.deprecation_reason
+
+          if @expected_reason.nil?
+            !actual_field.deprecation_reason.nil?
+          else
+            actual_field.deprecation_reason == @expected_reason
+          end
+        end
+
+        def failure_message
+          message = "#{description}, but it was "
+          message + (@actual_reason.nil? ? 'not deprecated' : "`#{@actual_reason}`")
+        end
+
+        def description
+          if @expected_reason.nil?
+            'with a deprecation reason'
+          else
+            "with deprecation reason `#{@expected_reason}`"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rspec/have_a_field_matcher_spec.rb
+++ b/spec/rspec/have_a_field_matcher_spec.rb
@@ -104,6 +104,60 @@ module RSpec::GraphqlMatchers
           )
         end
       end
+
+      describe '.with_deprecation_reason' do
+        context 'when the field has a deprecation reason' do
+          let(:deprecated_field) { :deprecated_field }
+
+          context 'with an expected deprecation reason' do
+            it 'passes when the deprecation reasons match' do
+              expect(a_type).to have_a_field(deprecated_field)
+                .with_deprecation_reason('deprecated')
+            end
+
+            it 'fails when the deprecation reasons do not match' do
+              expect do
+                expect(a_type).to have_a_field(deprecated_field)
+                  .with_deprecation_reason('different deprecation reason')
+              end.to fail_with(
+                'expected TestObject to define field `deprecated_field` with ' \
+                'deprecation reason `different deprecation reason`, ' \
+                'but it was `deprecated`'
+              )
+            end
+          end
+
+          context 'without an expected deprecation reason' do
+            it 'passes' do
+              expect(a_type).to have_a_field(deprecated_field).with_deprecation_reason
+            end
+          end
+        end
+
+        context 'when the field does not have a deprecation reason' do
+          let(:non_deprecated_field) { :id }
+
+          it 'fails without an expected deprecation reason' do
+            expect do
+              expect(a_type).to have_a_field(non_deprecated_field)
+                .with_deprecation_reason
+            end.to fail_with(
+              'expected TestObject to define field `id` with a deprecation reason, ' \
+              'but it was not deprecated'
+            )
+          end
+
+          it 'fails with an expected deprecation reason' do
+            expect do
+              expect(a_type).to have_a_field(non_deprecated_field)
+                .with_deprecation_reason('deprecated')
+            end.to fail_with(
+              'expected TestObject to define field `id` with deprecation reason `deprecated`, ' \
+              'but it was not deprecated'
+            )
+          end
+        end
+      end
     end
 
     context 'using the new class-based api' do
@@ -115,6 +169,8 @@ module RSpec::GraphqlMatchers
           field :other, types.String, hash_key: :other_on_hash, null: true
           field :is_test, types.Boolean, null: true
           field :not_camelized, types.String, null: false, camelize: false
+          field :deprecated_field, types.String, null: true,
+                                                 deprecation_reason: 'deprecated'
         end
       end
 
@@ -129,6 +185,8 @@ module RSpec::GraphqlMatchers
             field :other, types.String, hash_key: :other_on_hash, null: true
             field :is_test, types.Boolean, null: true
             field :not_camelized, types.String, null: false, camelize: false
+            field :deprecated_field, types.String, null: true,
+                                                   deprecation_reason: 'deprecated'
           end
 
           Class.new(GraphQL::Schema::Object) do
@@ -161,6 +219,8 @@ module RSpec::GraphqlMatchers
           field :isTest, types.Boolean
 
           field :not_camelized, types.String, camelize: false
+
+          field :deprecated_field, types.String, deprecation_reason: 'deprecated'
         end
       end
 


### PR DESCRIPTION
Adds a matcher for `deprecation_reason` on `have_a_field`
User can choose not to pass an argument to `with_deprecation_reason`, in which case it simply validates whether or not the field is deprecated.