### PR TITLE
Added RSpec as a runtime and development dependency for the gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.1 (Aug 2nd, 2021)
+-   Corrected gem dependencies so it properly requires RSpec when loaded (thanks to @itay-grudev)
+
 ## 1.3.0 (May 7th, 2020)
 
 -   `accept_argument` matcher accepts underscored argument names and passes even if the actual argument is camel-cased (https://github.com/khamusa/rspec-graphql_matchers/pull/32 thanks to @TonyArra);

--- a/lib/rspec/graphql_matchers/version.rb
+++ b/lib/rspec/graphql_matchers/version.rb
@@ -2,6 +2,6 @@
 
 module Rspec
   module GraphqlMatchers
-    VERSION = '1.3.0'.freeze
+    VERSION = '1.3.1'.freeze
   end
 end

--- a/rspec-graphql_matchers.gemspec
+++ b/rspec-graphql_matchers.gemspec
@@ -25,11 +25,11 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'graphql', '>= 1.8', '< 2.0'
+  spec.add_dependency 'graphql', '>= 1.8', '< 2.0'
+  spec.add_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'bundler', '~> 2.0'
   # CodeClimate does not yet support SimpleCov 0.18
   spec.add_development_dependency 'simplecov', '~>0.17.0'
   spec.add_development_dependency 'pry', '~> 0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '0.71'
 end


### PR DESCRIPTION
If RSpec is not a runtime dependency, if the gem is included before RSpec in your Gemfile it may results in issues, because RSpec hasn't been loaded yet.

For example, in my project this causes:

```txt
undefined method `configure' for RSpec:Module (NoMethodError)
```

The bypass is simple, add it after `gem 'rspec'`, but the actual cause is simply that the gem needs `RSpec` as a runtime dependency as well as a development dependency - hence the change.

P.S. I hope I wasn't being presumptions when filling your `CHANGELOG` and versions. I just wanted to save you the hassle of doing that.