### PR TITLE
Update to use #to_type_signature instead of #to_graphql

### DIFF
--- a/lib/rspec/graphql_matchers/base_matcher.rb
+++ b/lib/rspec/graphql_matchers/base_matcher.rb
@@ -16,7 +16,7 @@ module RSpec
       end
 
       def type_name(a_type)
-        a_type = a_type.to_graphql if a_type.respond_to?(:to_graphql)
+        a_type = a_type.to_type_signature if a_type.respond_to?(:to_type_signature)
 
         a_type.to_s
       end

--- a/lib/rspec/graphql_matchers/be_of_type.rb
+++ b/lib/rspec/graphql_matchers/be_of_type.rb
@@ -28,9 +28,9 @@ module RSpec
       private
 
       def to_graphql(field_sample)
-        return field_sample unless field_sample.respond_to?(:to_graphql)
+        return field_sample unless field_sample.respond_to?(:to_type_signature)
 
-        field_sample.to_graphql
+        field_sample.to_type_signature
       end
     end
   end

--- a/lib/rspec/graphql_matchers/have_a_field.rb
+++ b/lib/rspec/graphql_matchers/have_a_field.rb
@@ -80,7 +80,7 @@ module RSpec
           field = field_collection[@expected_field_name]
           field ||= field_collection[@expected_camel_field_name]
 
-          field.respond_to?(:to_graphql) ? field.to_graphql : field
+          field.respond_to?(:to_type_signature) ? field.to_type_signature : field
         end
       end
 


### PR DESCRIPTION
[graphql 1.13.1 deprecated #to_graphql](https://github.com/rmosolgo/graphql-ruby/pull/3765), making this change necessary.

[#to_type_signature seems to have been added in ruby-graphql 1.8.3](https://github.com/rmosolgo/graphql-ruby/commit/8fac52ab520c4441fe44610e0d34d0aecb7620a3) so this shouldn't be a breaking change for most users.
