### PR TITLE
Add deprecated_reason support for arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ class PostType < GraphQL::Schema::Object
     argument :filter, types.String, required: false
     argument :id, types.ID, required: false
     argument :isPublished, types.Boolean, required: false
+    argument :published, types.String, required: false, deprecation_reason: 'Use isPublished instead'
   end
 end
 ```
@@ -128,6 +129,9 @@ describe PostType do
       expect(subject).to accept_argument(:filter).of_type('String')
       expect(subject).to accept_argument(:id).of_type('ID')
     end
+
+    # Check a argument is deprecated
+    it { is_expected.to accept_argument(:published).with_deprecation_reason }
 
     it { is_expected.not_to accept_argument(:weirdo) }
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,15 @@ This project is intended to be a safe, welcoming space for collaboration, and
 contributors are expected to adhere to the
 [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
+## Testing
+
+```
+gem install diff-lcs
+bundle install
+```
+
+Run tests!
+
 ## License
 
 The gem is available as open source under the terms of the

--- a/lib/rspec/graphql_matchers/accept_argument.rb
+++ b/lib/rspec/graphql_matchers/accept_argument.rb
@@ -2,6 +2,7 @@
 
 require_relative 'base_matcher'
 require_relative './have_a_field_matchers/of_type'
+require_relative './have_a_field_matchers/with_deprecation_reason'
 
 module RSpec
   module GraphqlMatchers
@@ -40,6 +41,11 @@ module RSpec
 
       def of_type(expected_field_type)
         @expectations << HaveAFieldMatchers::OfType.new(expected_field_type)
+        self
+      end
+
+      def with_deprecation_reason(expected_reason = nil)
+        @expectations << HaveAFieldMatchers::WithDeprecationReason.new(expected_reason)
         self
       end
 

--- a/spec/rspec/accept_argument_matcher_spec.rb
+++ b/spec/rspec/accept_argument_matcher_spec.rb
@@ -106,10 +106,22 @@ module RSpec
             argument :is_test, GraphQL::Types::Boolean, required: false
             argument :not_camelized, GraphQL::Types::Boolean, required: false,
                                                               camelize: false
+            argument :deprecated_argument, types.String, required: false,
+                                                         deprecation_reason: 'deprecated'
+
           end
         end
 
         include_examples 'accept argument'
+
+        describe '.with_deprecation_reason' do
+          let(:deprecated_argument) { :deprecated_argument }
+
+          it 'passes when the deprecation reasons match' do
+            expect(a_type).to accept_argument(deprecated_argument)
+              .with_deprecation_reason('deprecated')
+          end
+        end
       end
 
       context 'with legacy DSL api' do


### PR DESCRIPTION
This extends the `accepts_argument` matcher adding support for deprecated arguments which was introduced [here](https://github.com/rmosolgo/graphql-ruby/pull/3015).

Usage:

```
describe MyObject do
  subject { described_class }

  it { is_expected.to accept_argument(:published).with_deprecation_reason }
end
```

I also added some dependency requirements to the readme :)

