### PR TITLE
Quote 3.0 in CI.  Upgrade checkout action version.  Use built-in caching

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -12,30 +12,17 @@ jobs:
 
     strategy:
       matrix:
-        ruby_version: [2.6, 2.7, 3.0, 3.1, 3.2]
+        ruby_version: [2.6, 2.7, '3.0', 3.1, 3.2]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Ruby ${{ matrix.ruby_version }}
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
-
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
-
-      - name: Cache gems
-        uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-${{ matrix.ruby_version }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.ruby_version }}-gems-
-
+          bundler-cache: true
       - name: Run RSpec
         run: bundle exec rspec


### PR DESCRIPTION
This addresses a few issues in CI:

1. Quotes "3.0", so CI doesn't truncate it to "3".  This ensures that a 3.0.x version is loaded.
2. Upgrade the checkout action version to v3 to eliminate Node v12 warning.
3. Uses bundler-cache to eliminate the use of the cache action (which also needs to be upgraded) 